### PR TITLE
Feat: Aura fullscreen

### DIFF
--- a/app/Http/Livewire/AuraWidget.php
+++ b/app/Http/Livewire/AuraWidget.php
@@ -11,6 +11,7 @@ class AuraWidget extends Component
     public $inputMessage;
     public $messages;
     public $token;
+    public $type;
     public $login = false;
     public $loginError = false;
     public $loginErrorMessage = '';
@@ -24,6 +25,7 @@ class AuraWidget extends Component
                             ];
         $this->inputMessage = '';
         $this->token = request()->token;
+        $this->type = request()->type;
     }
 
     public function render()

--- a/public/css/aura.css
+++ b/public/css/aura.css
@@ -77,9 +77,16 @@ body,html {
 }
 
 .card {
-    height: 550px;
+    height: 100%;
+    background: linear-gradient(to right, #ffffff, #EAF2F5)!important;
+    border: 0px;
+}
+
+.border-radius-15 {
     border-radius: 15px!important;
-    background: linear-gradient(to right, #FEEED0, #EAF2F5)!important
+}
+.border-radius-0 {
+    border-radius: 0px!important;
 }
 
 .msg_card_body {
@@ -91,7 +98,6 @@ body,html {
 
 .card-header {
     height: 20%;
-    border-radius: 15px 15px 0 0!important;
     border-bottom: 0!important
 }
 
@@ -207,7 +213,7 @@ body,html {
     margin-bottom: auto;
     margin-right: 10px;
     border-radius: 25px;
-    background-color: #FEE6B9;
+    background-color: #ffefd2;
     padding: 10px;
     position: relative
 }
@@ -242,12 +248,12 @@ body,html {
 }
 
 ::-webkit-scrollbar-thumb {
-    background: #FDDDA1;
+    background: #faf2e4;
     border-radius: 10px
 }
 
 ::-webkit-scrollbar-thumb:hover {
-    background: #FCCC72
+    background: #ffe7bb
 }
 
 .pt_10 {

--- a/resources/views/livewire/aura-widget.blade.php
+++ b/resources/views/livewire/aura-widget.blade.php
@@ -1,10 +1,21 @@
 
 <div class="container-fluid h-100" >
+
+    @if($type == 'button')
     <input type="checkbox" id="check"> <label class="chat-btn" for="check"><img height="45px" width="45px" src="{{ asset('img/aura/aura_icon.png') }}" /></label>
     <div class="wrapper">
+    @endif
+    
         <div class="row justify-content-center h-100">
+            
+            @if($type == 'button')
             <div class="col-md-12 col-xl-12 chat h-100"  >
-                <div class="card h-100" >
+                <div class="card border-radius-15 h-100" >
+            @endif
+            @if($type == 'fullscreen')
+            <div class="chat w-100 h-100"  >
+                <div class="card border-radius-0 h-100" > 
+            @endif
                     <div class="card-header msg_head" >
                         <div class="d-flex bd-highlight header_height" >
                             <div >
@@ -85,5 +96,8 @@
                 </div>
             </div>
         </div>
+    @if($type == 'button')
     </div>
+    @endif
+    
 </div>

--- a/routes/api/v0.php
+++ b/routes/api/v0.php
@@ -32,7 +32,7 @@ use Illuminate\Support\Facades\Route;
 Route::post('/auth', [AuthController::class, 'index'])->name('auth');
 Route::get('/checkin/marker', [CheckinController::class, 'marker']);
 
-// Aura Widged
+// Aura Widget
 Route::get('/widgets/aura', AuraWidget::class);
 
 // Authendicated routes


### PR DESCRIPTION
Não foi necessário criar uma nova rota pra aura, assim como eu tinha pensado que teria que criar.

Ao invés disso eu pensei em passar um parâmetro na url mesmo, juntamente com o JWT token caso houver, com o nome 'type', onde que se o type for igual a 'fullscreen' então será em tela cheia (pra usar nos iframes dos apps), e se for 'button' então será o botão de antes no canto inferior direito.

```
http://127.0.0.1:8000/v0/widgets/aura?token=kqwmdkqwd123k12p1ked12de12&type=button
```
```
http://127.0.0.1:8000/v0/widgets/aura?token=kqwmdkqwd123k12p1ked12de12&type=fullscreen
```
```
http://127.0.0.1:8000/v0/widgets/aura?type=button
```
```
http://127.0.0.1:8000/v0/widgets/aura?type=fullscreen
```

<hr />

![image](https://user-images.githubusercontent.com/48657331/162234369-25f23afd-0f44-4130-a8b2-16055a615963.png)

![image](https://user-images.githubusercontent.com/48657331/162234444-ec7dc339-30fc-40c8-a5fe-98b3b419b3a4.png)

fix: #28 