### PR TITLE
Feat: É necessário adicionar a mensagem para aceitar o uso de dados 

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -23,12 +23,14 @@ class CreateNewUser implements CreatesNewUsers
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => $this->passwordRules(),
+            'aura_consent' => ['integer']
         ])->validate();
 
         return User::create([
             'name' => $input['name'],
             'email' => $input['email'],
             'password' => Hash::make($input['password']),
+            'aura_consent' => $input['aura_consent'],
         ]);
     }
 }

--- a/app/Auth/CredentialManager.php
+++ b/app/Auth/CredentialManager.php
@@ -149,11 +149,11 @@ class CredentialManager
 
         // Se o token não for válido, o método abaixo levanta uma exceção.
         $payload = $this->checkPassport($jwt, $key);
-
+        
         $appId = $payload->app_id;
         $informedUser = (array) $payload->user;
         $user = User::where('uid', $informedUser['uid'])->first();
-
+ 
         if (!$user) {
             $user = $this->createUserFromPassportInfo($informedUser);
         }
@@ -171,6 +171,7 @@ class CredentialManager
     }
 
     public function createUserFromPassportInfo(array $info) {
+        
         if (empty($info['uid']) || empty($info['email'])) {
             throw new \Exception('Missing uid or email in passport info');
         }
@@ -179,19 +180,26 @@ class CredentialManager
         $password = Hash::make($uid . $info['email']);
 
         $user = User::where(['uid' => $uid])->first();
-        $data = [
-            'uid' => $uid,
-            'email' => $info['email'],
-            'name' => $info['name'],
-            'password' => $password
-        ];
+
 
         if($user) {
+            $data = [
+                'uid' => $uid,
+                'email' => $info['email'],
+                'name' => $info['name'],
+                'password' => $password
+            ];
             $user->update($data);
         } else {
+            $data = [
+                'uid' => $uid,
+                'email' => $info['email'],
+                'name' => $info['name'],
+                'password' => $password,
+                'aura_consent' => 0
+            ];
             $user = User::create($data);
         }
-
         return $user;
     }
 }

--- a/app/Http/Controllers/API/V0/AuthController.php
+++ b/app/Http/Controllers/API/V0/AuthController.php
@@ -19,7 +19,8 @@ class AuthController extends Controller
     }
 
     protected function createPassport($appId, $uid, $email, $name)
-    {
+    {   
+        
         if ($appId == null || $appId == 0) {
             return null;
         }
@@ -86,7 +87,6 @@ class AuthController extends Controller
 
         $input = $request->all();
         $info = $this->attemptAuthentication($input);
-
         if ($info === null) {
             return response()->json([
                 'message' => 'Usuário ou senha incorretos',
@@ -97,12 +97,14 @@ class AuthController extends Controller
         }
 
         $user = $this->credentialManager->createUserFromPassportInfo($info);
+ 
         $passport = $this->createPassport($request->input('app_id'),
                                           $info['uid'],
                                           $info['email'],
                                           $info['name']);
-
         $this->createScrapersIfNeeded($user, $input);
+        
+        $userFromDatabase = User::where(['uid' => $info['uid']])->first();
 
         return response()->json([
             'passport' => $passport,
@@ -111,7 +113,8 @@ class AuthController extends Controller
                 'email' => $info['email'],
                 'username' => $info['username'],
                 'uid' => $info['uid'],
-                'pessoa_id' => $info['pessoa_id']
+                'pessoa_id' => $info['pessoa_id'],
+                'aura_consent' => $userFromDatabase->aura_consent
             ]
         ]);
     }

--- a/app/Http/Controllers/API/V0/UserController.php
+++ b/app/Http/Controllers/API/V0/UserController.php
@@ -35,4 +35,27 @@ class UserController extends Controller
     {
         return response()->json($request->user());
     }
+
+    public function consent(Request $request)
+    {   
+        $user = $request->user();
+        $data = [
+            'aura_consent' => 1
+        ];
+        $user->update($data);
+
+        return response()->json(['aura_consent' => $user->aura_consent]);
+    }
+    public function unconsent(Request $request)
+    {   
+        // We're not saving this user's message history yet
+        // Here should be done the deletion of the message history of this user
+        $user = $request->user();
+        $data = [
+            'aura_consent' => 0
+        ];
+        $user->update($data);
+
+        return response()->json(['aura_consent' => $user->aura_consent]);
+    }
 }

--- a/app/Http/Livewire/AuraWidget.php
+++ b/app/Http/Livewire/AuraWidget.php
@@ -14,7 +14,9 @@ class AuraWidget extends Component
     public $type;
     public $agreeForm;
     public $agreed;
+    public $disagreeForm;
     public $login;
+    public $loggedIn;
     public $loginError;
     public $loginErrorMessage = '';
     public $username;
@@ -24,8 +26,10 @@ class AuraWidget extends Component
     public function mount()
     {   
         $this->agreeForm = false;
+        $this->disagreeForm = false;
         $this->agreed = false;
         $this->login = false;
+        $this->loggedIn = false;
         $this->loginError = false;
         $this->messages[0] = ['message' => 'Olá! Eu sou a AURA, uma assistente virtual desenvolvida pelo PRACTICE, converse comigo!',
                               'source' => 'aura'    
@@ -122,7 +126,7 @@ class AuraWidget extends Component
                 $this->loginErrorMessage = 'Usuário ou senha incorreto';
             } else {
                 $this->login = false;
-                
+                $this->loggedIn = true;
                 $this->token = $data->passport;
                 if ($data->user->aura_consent == '1'){
                     $this->agreed = true;
@@ -149,10 +153,38 @@ class AuraWidget extends Component
         }
     }
     public function consentUseOfData(){
-        $this->agreed = true;
-        $this->agreeForm = false;
+        $requestUrl = '/v0/user/aura_consent';
+        $request = Request::create($requestUrl, 'GET');
+        if ($this->token != null){
+            $request->headers->set('Authorization', 'Bearer '.$this->token);
+        } 
+        $response = json_decode(app()->handle($request)->getContent());
+        if ($response->aura_consent == 1){
+            $this->agreed = true;
+            $this->agreeForm = false;
+        } else {
+            dd("Não conseguimos aceitar o seu consentimento, erro nos servidores...");
+        }
     }
-    public function notConsentUseOfData(){
-        dd("F, ñ consentiu ");
+    public function unonsentUseOfData(){
+        $requestUrl = '/v0/user/aura_unconsent';
+        $request = Request::create($requestUrl, 'GET');
+        if ($this->token != null){
+            $request->headers->set('Authorization', 'Bearer '.$this->token);
+        } 
+        $response = json_decode(app()->handle($request)->getContent());
+        if ($response->aura_consent == 0){
+            $this->disagreeForm = true;
+            $this->agreeForm = false;
+            
+        } else {
+            dd("Não conseguimos aceitar o seu não consentimento, erro nos servidores...");
+        }
     }
+
+    public function displayAgreeForm(){
+        $this->agreeForm = true;
+        $this->disagreeForm = false;
+    }
+    
 }

--- a/app/Http/Livewire/AuraWidget.php
+++ b/app/Http/Livewire/AuraWidget.php
@@ -12,15 +12,19 @@ class AuraWidget extends Component
     public $messages;
     public $token;
     public $type;
-    public $login = false;
-    public $loginError = false;
+    public $agreedForm;
+    public $login;
+    public $loginError;
     public $loginErrorMessage = '';
     public $username;
     public $password;
     public $profilePic;
 
     public function mount()
-    {
+    {   
+        $this->agreedForm = false;
+        $this->login = false;
+        $this->loginError = false;
         $this->messages[0] = ['message' => 'Olá! Eu sou a AURA, uma assistente virtual desenvolvida pelo PRACTICE, converse comigo!',
                               'source' => 'aura'    
                             ];
@@ -79,6 +83,8 @@ class AuraWidget extends Component
                     $this->login = true;
                 }
             } else { 
+                // Aqui tem que fazer a verificação na própia api se o usuário já consentiu com o uso de dados
+                // then{$this->agreed = true}
                 if (property_exists($response, 'answer')) {
                     array_unshift($this->messages, ['message' => $response->answer,
                                                 'source' => 'aura'   
@@ -110,12 +116,12 @@ class AuraWidget extends Component
 
             $data = json_decode($response->getContent());
             
-            
             if ($data == null){
                 $this->loginError = true;
                 $this->loginErrorMessage = 'Usuário ou senha incorreto';
             } else {
                 $this->login = false;
+                $this->agreedForm = true;
                 $this->token = $data->passport;
 
                 $this->profilePic = "https://cc.uffs.edu.br/avatar/iduffs/".$data->user->uid;
@@ -135,8 +141,11 @@ class AuraWidget extends Component
             $this->loginErrorMessage = 'Ambos os campos devem ser preenchidos';
             return;
         }
-
-
-        
+    }
+    public function consentUseOfData(){
+        $this->agreedForm = false;
+    }
+    public function notConsentUseOfData(){
+        dd("F, ñ consentiu ");
     }
 }

--- a/app/Http/Livewire/AuraWidget.php
+++ b/app/Http/Livewire/AuraWidget.php
@@ -12,7 +12,8 @@ class AuraWidget extends Component
     public $messages;
     public $token;
     public $type;
-    public $agreedForm;
+    public $agreeForm;
+    public $agreed;
     public $login;
     public $loginError;
     public $loginErrorMessage = '';
@@ -22,7 +23,8 @@ class AuraWidget extends Component
 
     public function mount()
     {   
-        $this->agreedForm = false;
+        $this->agreeForm = false;
+        $this->agreed = false;
         $this->login = false;
         $this->loginError = false;
         $this->messages[0] = ['message' => 'Olá! Eu sou a AURA, uma assistente virtual desenvolvida pelo PRACTICE, converse comigo!',
@@ -83,8 +85,7 @@ class AuraWidget extends Component
                     $this->login = true;
                 }
             } else { 
-                // Aqui tem que fazer a verificação na própia api se o usuário já consentiu com o uso de dados
-                // then{$this->agreed = true}
+                
                 if (property_exists($response, 'answer')) {
                     array_unshift($this->messages, ['message' => $response->answer,
                                                 'source' => 'aura'   
@@ -121,8 +122,13 @@ class AuraWidget extends Component
                 $this->loginErrorMessage = 'Usuário ou senha incorreto';
             } else {
                 $this->login = false;
-                $this->agreedForm = true;
+                
                 $this->token = $data->passport;
+                if ($data->user->aura_consent == '1'){
+                    $this->agreed = true;
+                } else {
+                    $this->agreeForm = true;
+                }
 
                 $this->profilePic = "https://cc.uffs.edu.br/avatar/iduffs/".$data->user->uid;
 
@@ -143,7 +149,8 @@ class AuraWidget extends Component
         }
     }
     public function consentUseOfData(){
-        $this->agreedForm = false;
+        $this->agreed = true;
+        $this->agreeForm = false;
     }
     public function notConsentUseOfData(){
         dd("F, ñ consentiu ");

--- a/app/Http/Livewire/AuraWidget.php
+++ b/app/Http/Livewire/AuraWidget.php
@@ -163,7 +163,9 @@ class AuraWidget extends Component
             $this->agreed = true;
             $this->agreeForm = false;
         } else {
-            dd("Não conseguimos aceitar o seu consentimento, erro nos servidores...");
+            array_unshift($this->messages, ['message' => 'Não conseguimos aceitar o seu consentimento, erro nos servidores...',
+                                                'source' => 'aura'   
+                                                ]);
         }
     }
     public function unonsentUseOfData(){
@@ -176,9 +178,10 @@ class AuraWidget extends Component
         if ($response->aura_consent == 0){
             $this->disagreeForm = true;
             $this->agreeForm = false;
-            
         } else {
-            dd("Não conseguimos aceitar o seu não consentimento, erro nos servidores...");
+            array_unshift($this->messages, ['message' => 'Não conseguimos aceitar o seu não consentimento, erro nos servidores...',
+                                                'source' => 'aura'   
+                                                ]);
         }
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -37,7 +37,8 @@ class User extends Authenticatable
         'uid',
         'name',
         'email',
-        'password'
+        'password',
+        'aura_consent'
     ];
 
     /**

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -63,19 +63,25 @@ class JetstreamServiceProvider extends ServiceProvider
             $password = Hash::make($info->pessoa_id);
 
             $user = User::where(['uid' => $info->uid])->first();
-            $data = [
-                'uid' => $info->uid,
-                'email' => $info->email,
-                'name' => $info->name,
-                'password' => $password
-            ];
 
             if($user) {
+                $data = [
+                    'uid' => $info->uid,
+                    'email' => $info->email,
+                    'name' => $info->name,
+                    'password' => $password
+                ];
                 $user->update($data);
             } else {
+                $data = [
+                    'uid' => $info->uid,
+                    'email' => $info->email,
+                    'name' => $info->name,
+                    'password' => $password,
+                    'aura_consent' => 0
+                ];
                 $user = User::create($data);
             }
-
             return $user;
         });
     }

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -19,6 +19,7 @@ class CreateUsersTable extends Migration
             $table->string('name');
             $table->string('email')->index();
             $table->string('password');
+            $table->integer('aura_consent');
             $table->rememberToken();
             $table->text('profile_photo_path')->nullable();
             $table->timestamps();

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -15,8 +15,10 @@
         <link type="text/css" rel="stylesheet" href="{{asset('/css/aura.css')}}">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 
+        
         @livewireStyles
 
         <!-- Scripts -->

--- a/resources/views/livewire/aura-widget.blade.php
+++ b/resources/views/livewire/aura-widget.blade.php
@@ -1,12 +1,12 @@
 
 <div class="container-fluid h-100" >
+    
     @if($type == 'button')
     <input type="checkbox" id="check"> <label class="chat-btn" for="check"><img height="45px" width="45px" src="{{ asset('img/aura/aura_icon.png') }}" /></label>
     <div class="wrapper">
     @endif
     
         <div class="row justify-content-center h-100">
-            
             @if($type == 'button')
             <div class="col-md-12 col-xl-12 chat h-100"  >
                 <div class="card border-radius-15 h-100" >
@@ -59,6 +59,23 @@
                         
                     @endif
 
+                    @if ($agreedForm == true)
+                        <div class="d-flex justify-content-start mb-4">
+                            <div class="img_cont_msg">
+                                <img src="{{ asset('img/aura/aura_icon.png') }}" class="rounded-circle user_img_msg">
+                            </div>
+                            
+                            <div class="msg_cotainer">
+                                Para que eu consiga evoluir constantemente, todas as mensagens e interações que você fizer comigo são armazenadas, na íntegra. As mensagens não estão associadas a você (a autoria é anonimizada). Você concorda com isso?
+                                <div class="d-flex justify-content-around pt_10">
+                                    <button class="btn btn-primary" wire:click="consentUseOfData()" >Concordo</button>
+                                    <button class="btn btn-primary" wire:click="notConsentUseOfData()" >Discordo</button>
+                                </div>
+                                
+                            </div>
+                        </div>
+                    @endif
+
                     @foreach($messages as $message)
 
                         @if ($message['source'] == 'aura')
@@ -96,8 +113,20 @@
             
                     <div class="card-footer" >
                         <div class="input-group" >
-                            <input wire:model="inputMessage" wire:keydown.enter="sendMessage" type="text" class="form-control type_msg" placeholder="Escreva sua mensagem..."></input>
-                            <a class="input-group-text send_btn" wire:click="sendMessage()"><i class="fas fa-location-arrow"></i></a>
+                            @if($login == false)
+                                @if($agreedForm == false)
+                                    <input wire:model="inputMessage" wire:keydown.enter="sendMessage" type="text" class="form-control type_msg" placeholder="Escreva sua mensagem..."></input>
+                                    <a class="input-group-text send_btn" wire:click="sendMessage()"><i class="fas fa-location-arrow"></i></a>
+                                @else
+                                    
+                                    <input wire:model="inputMessage" wire:keydown.enter="sendMessage" type="text" class="form-control type_msg" placeholder="Escreva sua mensagem..." disabled></input>
+                                    <a class="input-group-text send_btn" wire:click="sendMessage()" disabled><i class="fas fa-location-arrow"></i></a>
+                                @endif    
+                            @else
+                                <input wire:model="inputMessage" wire:keydown.enter="sendMessage" type="text" class="form-control type_msg" placeholder="Escreva sua mensagem..." disabled></input>
+                                <a class="input-group-text send_btn" wire:click="sendMessage()" disabled><i class="fas fa-location-arrow"></i></a>
+                            @endif
+                            
                         </div>
                     </div>
                 </div>

--- a/resources/views/livewire/aura-widget.blade.php
+++ b/resources/views/livewire/aura-widget.blade.php
@@ -15,17 +15,37 @@
             <div class="chat w-100 h-100"  >
                 <div class="card border-radius-0 h-100" > 
             @endif
-                    <div class="card-header msg_head" >
-                        <div class="d-flex bd-highlight header_height" >
-                            <div >
+                    <div class="card-header msg_head">
+                        <div class="d-flex bd-highlight header_height">
+                            <div class="p-2">
                                 <img src="{{ asset('img/aura/aura_icon_online.png') }}" class="user_img">
                             </div>
-                            <div class="user_info" >
+                            <div class="user_info p-2">
                                 <span>Aura</span>
                                 <p class="ia_practice">Inteligencia Artificial do PRACTICE</p>
                                 <p class="practice">PRACTICE</p>
                             </div>
+                            @if ($loggedIn == true)
+                            <div class="ml-auto p-2">
+                                <div class="dropdown">
+                                    <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    </button>
+                                    <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                        @if ($agreed == true)
+                                            @if ($disagreeForm == true)
+                                                <a class="dropdown-item" href="#" wire:click="displayAgreeForm()">Concordar com o uso de dados</a>
+                                            @else
+                                                <a class="dropdown-item" href="#" wire:click="displayAgreeForm()">Discordar com o uso de dados</a>
+                                            @endif  
+                                        @else
+                                            <a class="dropdown-item" href="#" wire:click="displayAgreeForm()">Concordar com o uso de dados</a>
+                                        @endif    
+                                    </div>
+                                </div>
+                            </div>
+                            @endif
                         </div> 
+                    
                     </div>
                     <div class="card-body msg_card_body ">
                     @if($login == true)
@@ -69,9 +89,21 @@
                                 Para que eu consiga evoluir constantemente, todas as mensagens e interações que você fizer comigo são armazenadas, na íntegra. As mensagens não estão associadas a você (a autoria é anonimizada). Você concorda com isso?
                                 <div class="d-flex justify-content-around pt_10">
                                     <button class="btn btn-primary" wire:click="consentUseOfData()" >Concordo</button>
-                                    <button class="btn btn-primary" wire:click="notConsentUseOfData()" >Discordo</button>
+                                    <button class="btn btn-primary" wire:click="unonsentUseOfData()" >Discordo</button>
                                 </div>
                                 
+                            </div>
+                        </div>
+                    @endif
+
+                    @if ($disagreeForm == true)
+                        <div class="d-flex justify-content-start mb-4">
+                            <div class="img_cont_msg">
+                                <img src="{{ asset('img/aura/aura_icon.png') }}" class="rounded-circle user_img_msg">
+                            </div>
+                            
+                            <div class="msg_cotainer">
+                                O histórico de suas mensagens foram exluídos e não armazenaremos mais os teus dados relacionados à Aura... No entanto, não posso mais conversar com você :(, caso queira conversar comigo, me dê a permissão para armazenar seus dados clicando do menu no canto superior direito
                             </div>
                         </div>
                     @endif
@@ -115,8 +147,13 @@
                         <div class="input-group" >
                             @if($login == false)
                                 @if($agreeForm == false)
-                                    <input wire:model="inputMessage" wire:keydown.enter="sendMessage" type="text" class="form-control type_msg" placeholder="Escreva sua mensagem..."></input>
-                                    <a class="input-group-text send_btn" wire:click="sendMessage()"><i class="fas fa-location-arrow"></i></a>
+                                    @if($disagreeForm == false)
+                                        <input wire:model="inputMessage" wire:keydown.enter="sendMessage" type="text" class="form-control type_msg" placeholder="Escreva sua mensagem..."></input>
+                                        <a class="input-group-text send_btn" wire:click="sendMessage()"><i class="fas fa-location-arrow"></i></a>
+                                    @else
+                                        <input wire:model="inputMessage" wire:keydown.enter="sendMessage" type="text" class="form-control type_msg" placeholder="Escreva sua mensagem..." disabled></input>
+                                        <a class="input-group-text send_btn" wire:click="sendMessage()" disabled><i class="fas fa-location-arrow"></i></a>
+                                    @endif  
                                 @else
                                     
                                     <input wire:model="inputMessage" wire:keydown.enter="sendMessage" type="text" class="form-control type_msg" placeholder="Escreva sua mensagem..." disabled></input>

--- a/resources/views/livewire/aura-widget.blade.php
+++ b/resources/views/livewire/aura-widget.blade.php
@@ -59,7 +59,7 @@
                         
                     @endif
 
-                    @if ($agreedForm == true)
+                    @if ($agreeForm == true)
                         <div class="d-flex justify-content-start mb-4">
                             <div class="img_cont_msg">
                                 <img src="{{ asset('img/aura/aura_icon.png') }}" class="rounded-circle user_img_msg">
@@ -114,7 +114,7 @@
                     <div class="card-footer" >
                         <div class="input-group" >
                             @if($login == false)
-                                @if($agreedForm == false)
+                                @if($agreeForm == false)
                                     <input wire:model="inputMessage" wire:keydown.enter="sendMessage" type="text" class="form-control type_msg" placeholder="Escreva sua mensagem..."></input>
                                     <a class="input-group-text send_btn" wire:click="sendMessage()"><i class="fas fa-location-arrow"></i></a>
                                 @else

--- a/routes/api/v0.php
+++ b/routes/api/v0.php
@@ -78,7 +78,10 @@ Route::group(['middleware' => 'jwt.practice'], function () {
     Route::get('/{app}/me', [ApiProxyController::class, 'proxy']);
 
     // User
+    Route::get('/user/aura_consent', [UserController::class, 'consent']);
+    Route::get('/user/aura_unconsent', [UserController::class, 'unconsent']);
     Route::get('/user', [UserController::class, 'index']);
+   
 
     // Test
     Route::get('ping', [PingController::class, 'index']);


### PR DESCRIPTION
Implementei a mensagem de concordar e discordar com o consentimento do de uso de dados da aura, bloqueando o envio de mensagens quando não foi consentido.

Também implementei um atributo novo ao usuário, que é o que diz se o usuário já consentiu ou não com o uso dos dados, para não perguntar toda vez. 

Aqui vai o gif de como ficou: 

<hr />

![auraagree](https://user-images.githubusercontent.com/48657331/164945336-8d08cc89-9f25-4342-8126-93bb417b47d6.gif)




Fix: #41