### PR TITLE
feat: add questionnaires model, migration, controller and routes

### DIFF
--- a/app/Http/Controllers/API/V0/WellBeingQuestionnaireController.php
+++ b/app/Http/Controllers/API/V0/WellBeingQuestionnaireController.php
@@ -13,11 +13,17 @@ use App\Models\WellBeingQuestionnaire;
 class WellBeingQuestionnaireController extends Controller
 {
     /**
+        * @param  Request  $request
         * @return Response
     */
-    public function index()
+    public function index(Request $request)
     {
         $wellBeingQuestionnaire = WellBeingQuestionnaire::where('user_id', auth()->id())->get();
+
+        if($request->input('type') != null) {
+            $wellBeingQuestionnaire = WellBeingQuestionnaire::where('user_id', auth()->id())->where('type', $request->input('type'))->get();
+        }
+
         return response()->json(
             $wellBeingQuestionnaire, 
             Response::HTTP_OK

--- a/app/Http/Controllers/API/V0/WellBeingQuestionnaireController.php
+++ b/app/Http/Controllers/API/V0/WellBeingQuestionnaireController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Http\Controllers\API\V0;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Validator;
+
+use App\Models\WellBeingQuestionnaire;
+
+
+class WellBeingQuestionnaireController extends Controller
+{
+    /**
+        * @return Response
+    */
+    public function index()
+    {
+        $wellBeingQuestionnaire = WellBeingQuestionnaire::where('user_id', auth()->id())->get();
+        return response()->json(
+            $wellBeingQuestionnaire, 
+            Response::HTTP_OK
+        ); 
+    }
+
+
+    /**
+        * @param  Request  $request
+        * @return Response
+    */
+    public function store(Request $request)
+    {
+        $request['user_id'] = auth()->id();
+
+        $validator = Validator::make($request->all(), [
+            'user_id' => 'required|exists:users,id',
+            'type' => 'required|string',
+            'data' => 'required|array'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(
+                ['errors' => $validator->errors()], 
+                Response::HTTP_BAD_REQUEST
+            ); 
+        }
+
+        $wellBeingQuestionnaire = WellBeingQuestionnaire::create($request->all());
+
+        return response()->json(
+            $wellBeingQuestionnaire, 
+            Response::HTTP_CREATED
+        ); 
+    }
+
+
+    /**
+        * @param  Request  $request
+        * @return Response
+    */
+    public function show(Request $request)
+    {
+        $wellBeingQuestionnaire = WellBeingQuestionnaire::where('id', $request->id)->first();
+
+        return response()->json(
+            $wellBeingQuestionnaire, 
+            Response::HTTP_OK
+        ); 
+    }
+
+    /**
+        * @param  Request  $request
+        * @return Response
+    */
+    public function update(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'type' => 'required|string',
+            'data' => 'required|array'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(
+                ['errors' => $validator->errors()], 
+                Response::HTTP_BAD_REQUEST
+            ); 
+        }
+
+        WellBeingQuestionnaire::where('id', $request->id)->update($request->all());
+        $wellBeingQuestionnaire = WellBeingQuestionnaire::where('id', $request->id)->first();
+        if ($wellBeingQuestionnaire == NULL) {
+            return response()->json(
+                ['error' => "Registro com id $request->id não encontrado"],
+                Response::HTTP_NOT_FOUND
+            ); 
+        }
+
+        return response()->json(
+            $wellBeingQuestionnaire, 
+            Response::HTTP_OK
+        ); 
+    }
+
+    /**
+        * @param  Request  $request
+        * @return Response
+    */
+    public function destroy(Request $request)
+    {
+        $result = WellBeingQuestionnaire::where('id', $request->id)->delete();
+
+        if ($result != 1) {
+            return response()->json(
+                ['error' => "Registro com id $request->id não encontrado"],
+                Response::HTTP_NOT_FOUND
+            ); 
+        }
+
+        return response()->json(
+            NULL, 
+            Response::HTTP_OK
+        ); 
+    }
+}

--- a/app/Models/WellBeingQuestionnaire.php
+++ b/app/Models/WellBeingQuestionnaire.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\User;
+
+class WellBeingQuestionnaire extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'type',
+        'data',
+        'user_id'
+    ];
+
+    protected $casts = [
+        'data' => 'array'
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2022_04_25_180141_create_well_being_questionnaires_table.php
+++ b/database/migrations/2022_04_25_180141_create_well_being_questionnaires_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateWellBeingQuestionnairesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('well_being_questionnaires', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->index();
+            $table->string('type', 40)->index();
+            $table->json('data');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('well_being_questionnaires');
+    }
+}

--- a/routes/api/v0.php
+++ b/routes/api/v0.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\API\V0\PingController;
 use App\Http\Controllers\API\V0\TestController;
 use App\Http\Controllers\API\V0\UserController;
 use App\Http\Controllers\API\V0\AnalyticsController;
+use App\Http\Controllers\API\V0\WellBeingQuestionnaireController;
 use App\Http\Proxy\PracticeApiProxy;
 use App\Http\Livewire\AuraWidget;
 use Illuminate\Support\Facades\Route;
@@ -55,6 +56,13 @@ Route::group(['middleware' => 'jwt.practice'], function () {
     Route::patch('/analytics/{id}', [AnalyticsController::class, 'update']);
     Route::delete('/analytics/{id}', [AnalyticsController::class, 'destroy']);
 
+    // Questionário App Bem Estar
+    Route::get('/app-bem-estar/questionnaire', [WellBeingQuestionnaireController::class, 'index']);
+    Route::post('/app-bem-estar/questionnaire', [WellBeingQuestionnaireController::class, 'store']);
+    Route::get('/app-bem-estar/questionnaire/{id}', [WellBeingQuestionnaireController::class, 'show']);
+    Route::patch('/app-bem-estar/questionnaire/{id}', [WellBeingQuestionnaireController::class, 'update']);
+    Route::delete('/app-bem-estar/questionnaire/{id}', [WellBeingQuestionnaireController::class, 'destroy']);
+
     // Notification
     Route::get('user/notify/push', [NotificationController::class, 'push']);
 
@@ -66,6 +74,8 @@ Route::group(['middleware' => 'jwt.practice'], function () {
 
     // Informações acadêmicas
     Route::get('/aluno/historico', [AlunoController::class, 'historico']);    
+
+    
 
     // Proxy para apis de outros serviços
     // Mural


### PR DESCRIPTION
Adicionei o model com os seguintes campos:

- user_id
- type: minha ideia com esse campo seria dar a possibilidade de armazenar os dados de mais de um tipo de questionário (como por exemplo de alimentação, atividade física...) mas se não for necessário é possível retira-lo facilmente
- data: é um campo para salvar o json com as respostas, achei que um campo pra adicionar um json no formato "pergunta:resposta" seria melhor pois caso alguma pergunta seja alterada no futuro não vai ser necessario modificar o modelo do banco
- created_at
- updated_at
 

Quanto às rotas eu adicionei as rotas de `GET, POST, DELETE e PATCH` usando a url `/app-bem-estar/questionnaire` como base caso alguém tenha uma sugestão de uma rota base mais limpa ou mais intuitiva é possível alterar isso também. Para a rota de GET que retorna todos os registros (relacionados ao usuário que fez a requisição) eu adicionei a opção de inserir um query parameter "type" para filtrar os resultados retornados pelo tipo. Caso esse parâmetro não seja enviado a rota vai retornar todos os registos associados ao usuário que fez a requisição.

Acredito que seja bom o @SWE3T também revisar o que foi feito por ele ter mais contato com o App Bem Estar que deve ser atendido por esse PR.

Fix: #39 