### PR TITLE
Feat: #48  Fazer as rotas e migration/model para guardar o histórico

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -38,7 +38,8 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
-        'aura_consent'
+        'aura_consent',
+        'aura_history'
     ];
 
     /**
@@ -65,6 +66,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $casts = [
+        'aura_history' => 'array',
         'email_verified_at' => 'datetime',
     ];
 

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -20,6 +20,7 @@ class CreateUsersTable extends Migration
             $table->string('email')->index();
             $table->string('password');
             $table->integer('aura_consent');
+            $table->json('aura_history')->nullable();
             $table->rememberToken();
             $table->text('profile_photo_path')->nullable();
             $table->timestamps();

--- a/routes/api/v0.php
+++ b/routes/api/v0.php
@@ -90,6 +90,9 @@ Route::group(['middleware' => 'jwt.practice'], function () {
     // User
     Route::get('/user/aura_consent', [UserController::class, 'consent']);
     Route::get('/user/aura_unconsent', [UserController::class, 'unconsent']);
+    Route::post('/user/aura-history', [UserController::class, 'setAuraHistory']);
+    Route::get('/user/aura-history', [UserController::class, 'getAuraHistory']);
+    Route::delete('/user/aura-history', [UserController::class, 'deleteAuraHistory']);
     Route::get('/user', [UserController::class, 'index']);
    
 


### PR DESCRIPTION
Fiz as rotas básicas para guardar o históricos da aura em um JSON vinculado ao usuário, pode ser que sofram alterações no futuro a estas rotas:

*As rotas:*
``` php
post   '/user/aura-history'  ->  setAuraHistory()
get   '/user/aura-history'  ->  getAuraHistory()
delete   '/user/aura-history'  ->  deleteAuraHistory()
```

Route::post('/user/aura-history', [UserController::class, 'setAuraHistory']);
Route::get('/user/aura-history', [UserController::class, 'getAuraHistory']);
Route::delete('/user/aura-history', [UserController::class, 'deleteAuraHistory']);

![Peek 2022-05-20 10-02](https://user-images.githubusercontent.com/48657331/169533664-9673aaf8-744b-4f46-b1e5-3d20b0ff1fee.gif)


Fix: #48 