### PR TITLE
Salvar um histórico das mensagens do usuário com a Aura

### DIFF
--- a/app/Http/Controllers/API/V0/UserController.php
+++ b/app/Http/Controllers/API/V0/UserController.php
@@ -80,16 +80,22 @@ class UserController extends Controller
                 Response::HTTP_BAD_REQUEST
             ); 
         }
-
+       
+        if(is_array($request["aura_history"])){
+            $auraHistory = $request["aura_history"];
+        } else {
+            $auraHistory = json_decode($request["aura_history"]);
+        }
+        
+     
         $user = $request->user();
         if ($user->aura_history == null){
             $data = [
-                 'aura_history' => array($request["aura_history"])
+                 'aura_history' => array($auraHistory)
             ];
         } else {
             $history = $user->aura_history;
-            $newMessage = $request["aura_history"];
-            array_push ($history,$newMessage);
+            array_push ($history,$auraHistory);
             $data = [
                 'aura_history' => $history
             ];
@@ -104,6 +110,8 @@ class UserController extends Controller
     public function getAuraHistory(Request $request)
     {   
         $user = $request->user();
+
+        
         return response()->json(
             ['aura_history' => $user->aura_history],
             Response::HTTP_OK
@@ -124,7 +132,7 @@ class UserController extends Controller
         }
         
         return response()->json(
-            ['errors' => ['updated' => $updated]], 
+            ['errors' => ['bd_error' => $updated]], 
             Response::HTTP_BAD_REQUEST
         ); 
     }

--- a/app/Http/Controllers/API/V0/UserController.php
+++ b/app/Http/Controllers/API/V0/UserController.php
@@ -68,6 +68,16 @@ class UserController extends Controller
         );
     }
 
+    public function consentStatus(Request $request)
+    {   
+        $user = $request->user();
+
+        return response()->json(
+            ['aura_consent' => $user->aura_consent],
+            Response::HTTP_OK
+        );
+    }
+
     public function setAuraHistory(Request $request)
     {       
         $validator = Validator::make($request->all(), [

--- a/app/Http/Livewire/AuraWidget.php
+++ b/app/Http/Livewire/AuraWidget.php
@@ -352,6 +352,7 @@ class AuraWidget extends Component
                 array_unshift($this->messages, $message);
             }
         }
+        $this->messageId = $totalMessagesSize;
         $this->historyLoaded = true;
     }
     

--- a/app/Http/Livewire/AuraWidget.php
+++ b/app/Http/Livewire/AuraWidget.php
@@ -197,7 +197,6 @@ class AuraWidget extends Component
 
                 if ($historyResponse->aura_history != null){
                     foreach ($historyResponse->aura_history as $objectMessage) {
-                        $arrayMessage = json_decode(json_encode($objectMessage), true);
                         $arrayMessage = (array) $objectMessage;
                         array_unshift($this->messages, $arrayMessage);
                     }

--- a/public/css/aura.css
+++ b/public/css/aura.css
@@ -292,6 +292,10 @@ button.dislike{
 	font-size: 15px;
 }
 
+.load-history{
+    
+}
+
 ::-webkit-scrollbar {
     width: 10px
 }

--- a/resources/views/livewire/aura-widget.blade.php
+++ b/resources/views/livewire/aura-widget.blade.php
@@ -56,7 +56,7 @@
                                     </button>
                                     <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                                         @if ($agreed == true)
-                                            @if ($disagreeForm == true)
+                                            @if ($disagreedForm == true)
                                                 <a class="dropdown-item" href="#" wire:click="displayAgreeForm()">Concordar com o uso de dados</a>
                                             @else
                                                 <a class="dropdown-item" href="#" wire:click="displayAgreeForm()">Discordar com o uso de dados</a>
@@ -135,7 +135,7 @@
                         </div>
                     @endif
 
-                    @if ($disagreeForm == true)
+                    @if ($disagreedForm == true)
                         <div class="d-flex justify-content-start mb-4">
                             <div class="img_cont_msg">
                                 <img src="{{ asset('img/aura/aura_icon.png') }}" class="rounded-circle user_img_msg">
@@ -241,7 +241,7 @@
                         <div class="input-group" >
                             @if($login == false)
                                 @if($agreeForm == false)
-                                    @if($disagreeForm == false)
+                                    @if($disagreedForm == false)
                                         <input wire:model="inputMessage" wire:keydown.enter="sendMessage" type="text" class="form-control type_msg" placeholder="Escreva sua mensagem..."></input>
                                         <a class="input-group-text send_btn" wire:click="sendMessage()"><i class="fas fa-location-arrow"></i></a>
                                     @else

--- a/resources/views/livewire/aura-widget.blade.php
+++ b/resources/views/livewire/aura-widget.blade.php
@@ -234,7 +234,19 @@
                         @endif
 
                     @endforeach
-                
+
+                    @if ($loggedIn == true)
+                        @if ($historyLoaded == false)
+                        <div >
+                            <a wire:click="loadHistory">
+                                <p class="w-100 pt-3 pb-3 text-center text-muted">
+                                    <u>Mostrar mensagens anteriores</u>
+                                </p>
+                            </a>
+                        </div>
+                        @endif
+                    @endif
+
                     </div>
             
                     <div class="card-footer" >

--- a/routes/api/v0.php
+++ b/routes/api/v0.php
@@ -88,8 +88,9 @@ Route::group(['middleware' => 'jwt.practice'], function () {
     Route::get('/{app}/me', [ApiProxyController::class, 'proxy']);
 
     // User
-    Route::get('/user/aura_consent', [UserController::class, 'consent']);
-    Route::get('/user/aura_unconsent', [UserController::class, 'unconsent']);
+    Route::get('/user/aura-consent-status', [UserController::class, 'consentStatus']);
+    Route::get('/user/aura-consent', [UserController::class, 'consent']);
+    Route::get('/user/aura-unconsent', [UserController::class, 'unconsent']);
     Route::post('/user/aura-history', [UserController::class, 'setAuraHistory']);
     Route::get('/user/aura-history', [UserController::class, 'getAuraHistory']);
     Route::delete('/user/aura-history', [UserController::class, 'deleteAuraHistory']);


### PR DESCRIPTION
**É necessário rodar o _php artisan migrate:fresh_**

Esse PR faz a implementação do armazenamento do histórico de conversas com a Aura (utilizando a ideia do campo JSON), no caso do chat já possuir um token autenticado, daí o chat da a opção de ver mensagens antigas.

Eu era pra ter feito esse PR na segunda dia 23/05, só que fui encontrando bugs e ao mesmo tempo corrigindo eles :), eu tentei caçar o máximo de bugs que consegui, caso ainda notar algo estranho, só me dar um toque hehe :3

Para um chat sem token autenticado:

![Peek 2022-05-24 10-25](https://user-images.githubusercontent.com/48657331/170046070-37dbbec8-4fc2-4433-a90a-4481edbac86e.gif)

<hr />

Para um usuário com o token autenticado:
![Peek 2022-05-24 10-26](https://user-images.githubusercontent.com/48657331/170046442-1933f3bc-d204-444c-8516-ccbbc7bca01c.gif)





Fix: #45