### PR TITLE
add aura qna+domain route

### DIFF
--- a/app/Http/Controllers/API/V0/AuraController.php
+++ b/app/Http/Controllers/API/V0/AuraController.php
@@ -38,6 +38,21 @@ class AuraController extends Controller
      */
     public function index(string $route, string $text) {
         $response = $this->auraNLP->fetch($route, $text);
+        return response(
+            $response,
+            Response::HTTP_OK   
+        );
+    }
+
+    public function mix(string $text) {
+        $responseQNA = $this->auraNLP->fetch('qna', $text);
+        $response = $this->auraNLP->fetch('domain', $text);
+        
+        if ($responseQNA != null){
+            if (array_key_exists('answer', $responseQNA)) {
+                $response = $responseQNA;
+            } 
+        }
 
         return response(
             $response,

--- a/app/Http/Livewire/AuraWidget.php
+++ b/app/Http/Livewire/AuraWidget.php
@@ -83,7 +83,7 @@ class AuraWidget extends Component
         $this->messageId++;                                     
 
         $encodedUrl = rawurlencode($this->inputMessage);
-        $requestUrl = '/v0/aura/nlp/domain/' . $encodedUrl;
+        $requestUrl = '/v0/aura/nlp/' . $encodedUrl;
 
         
         $messageRequest = Request::create($requestUrl, 'GET');

--- a/app/Services/AuraNLP.php
+++ b/app/Services/AuraNLP.php
@@ -2,6 +2,9 @@
 
 namespace App\Services;
 
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Exception\RequestException;
+
 class AuraNLP
 {
     protected $config;
@@ -24,8 +27,13 @@ class AuraNLP
 
     public function fetch($route, $text)
     {
+       
         $url = $this->config['api_url'] . "/$route/" . rawurlencode($text);
-        $response = $this->client->get($url);
+        try {
+            $response = $this->client->get($url);
+        } catch (RequestException $e) {
+            $response = $e->getResponse();
+        }
 
         return json_decode($response->getBody()->getContents(), true);
     }

--- a/routes/api/v0.php
+++ b/routes/api/v0.php
@@ -41,6 +41,7 @@ Route::group(['middleware' => 'jwt.practice'], function () {
 
     // Aura
     Route::get('/aura/nlp/{route}/{text}', [AuraController::class, 'index']);
+    Route::get('/aura/nlp/{text}', [AuraController::class, 'mix']);
     Route::match(['GET', 'POST'], 'interact', [InteractionController::class, 'index']);
 
     // Channels


### PR DESCRIPTION
Criada a rota, ela bate em ```http://127.0.0.1:8000/v0/aura/nlp/{text}``` chama a função 'mix' e se tiver resposta no 'qna' retorna ela, se não tiver resposta ou o qna não estiver rodando retorna a resposta como se tivesse sido solicitada normalmente no 'domain'.

Para testar, é necessário a aura-nlp rodando com os dois models do qna e do domain, pode-se testar ou pelo POSTMAN ou pelo widget da aura.

[Os models qna e domain](https://drive.google.com/drive/folders/1LXcg_B_Yl3ZBphcKpdO1SlpZ_qMqEsMu?usp=sharing)