### PR TITLE
feat: handle links on Aura messages

### DIFF
--- a/app/Http/Livewire/AuraWidget.php
+++ b/app/Http/Livewire/AuraWidget.php
@@ -202,6 +202,15 @@ class AuraWidget extends Component
     }
 
     public function addMessageToChat(string $message, string $category, bool $save, string $userMessage = 'has_no_message', string $source = 'aura') {
+        if ($source ==  'aura') { // tratamento de links
+            if (preg_match('/\[(.+)\]\s*\((.+)\)/', $message)) {
+                $message = preg_replace('/\[(.+)\]\s*\((.+)\)/', '<a target="_blank" rel="noreferrer noopener" class="underline" href="$2">$1</a>', $message); // links no formato [texto](url)
+            } else {
+                $linkRegex = '/https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)/';
+                $message = preg_replace($linkRegex, '<a target="_blank" rel="noreferrer noopener" class="underline" href="$0">$0</a>', $message);
+            }
+        }
+
         array_unshift($this->messages, ['id' => count($this->messages) + 1,
                                         'message' => $message,
                                         'source' => $source,

--- a/public/css/aura.css
+++ b/public/css/aura.css
@@ -234,6 +234,14 @@ body,html {
     color: #efefef;
 }
 
+.msg_container_theme_dark a {
+    color: #efefef;
+    text-decoration: underline;
+}
+
+.msg_container_theme_dark a:hover {
+    color: #efefef;
+}
 
 .msg_container_send {
     margin-top: auto;

--- a/resources/views/livewire/aura-widget.blade.php
+++ b/resources/views/livewire/aura-widget.blade.php
@@ -112,7 +112,7 @@
                                 </div>
                                 
                                 <div class="text-break msg_container msg_container_theme_{{$widgetSettings['theme']}}">
-                                    {{ $message['message'] }}
+                                    {!! $message['message'] !!}
 
                                     @if ($this->user['token'] != null && $user['consent_status'] == 1)
                                         @if ($message['assessed'] == 2)    


### PR DESCRIPTION
Adicionei um regex que pega links e os transforma em elementos do tipo `<a>` para serem clicáveis. Além disso, adicionei outro regex que dá a opção de usar a marcação `[texto](url)` assim como no markdown. O único problema é que quando o widget é usado nos apps o mesmo abre dentro do app e não externamente no navegador.

fix: #65 