### PR TITLE
feat: academic calendar popup

### DIFF
--- a/app/Http/Controllers/API/V0/AcademicCalendarController.php
+++ b/app/Http/Controllers/API/V0/AcademicCalendarController.php
@@ -26,23 +26,25 @@ class AcademicCalendarController extends Controller
         ];
     }
 
-    public function getCalendars() {
-        $calendars = AcademicCalendar::all();
+    public function getCalendars($campus = null) {
+        $calendars = AcademicCalendar::where('title', 'LIKE', '%' . $campus . '%')->get();
 
         return $calendars;
     }
 
-    public function getCurrentMonthCalendar() {
+    public function getCurrentMonthCalendar($campus = null) {
         $currentMonth = $this->months[(int) date('n') - 1];
         $currentYear = (int) date('Y');
-        $calendar = $this->getCalendars();
+        $calendar = $this->getCalendars($campus);
 
         $currentMonthCalendar = $this->getCalendarEventsByMonth($calendar, $currentMonth, $currentYear);
 
         return $currentMonthCalendar;
     }
 
-    public function getCalendarEventsByMonth($calendars, $month, $year) {
+    public function getCalendarEventsByMonth($month, $year, $campus = null) {
+        $calendars = $this->getCalendars($campus);
+
         $currentMonthEvents = [];
         foreach ($calendars as $calendar) {
             foreach ($calendar['data'] as $key => $calendarMonth) {
@@ -68,11 +70,11 @@ class AcademicCalendarController extends Controller
     }
 
     // Recebe uma data no formato y-m-d
-    public function getCalendarEventsByDate($date) {
+    public function getCalendarEventsByDate($date, $campus = null) {
         $dateCalendar = [];
         $date = strtotime($date);
 
-        $calendar = $this->getCalendars();
+        $calendar = $this->getCalendars($campus);
         $month = $this->months[(int) date('n', $date) - 1];
         $year = date('Y', $date);
         $monthCalendars = $this->getCalendarEventsByMonth($calendar, $month, $year);

--- a/app/Http/Livewire/AuraAcademicCalendar.php
+++ b/app/Http/Livewire/AuraAcademicCalendar.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use Livewire\Component;
+
+class AuraAcademicCalendar extends Component
+{
+    public function render()
+    {
+        return view('livewire.aura-academic-calendar');
+    }
+
+    public function closePopup()
+    {
+        $this->emitUp('toggleCalendarPopup');
+    }
+
+    public function changeMonth($direction)
+    {
+        //
+    }
+}

--- a/app/Http/Livewire/AuraAcademicCalendar.php
+++ b/app/Http/Livewire/AuraAcademicCalendar.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace App\Http\Livewire;
+use App\Http\Controllers\API\V0\AcademicCalendarController;
+
 
 use Livewire\Component;
 
@@ -8,6 +10,9 @@ class AuraAcademicCalendar extends Component
 {
     public $months;
     public $calendar;
+    public $academicCalendar;
+    public $campus;
+    public $theme;
 
     public function render()
     {
@@ -17,7 +22,7 @@ class AuraAcademicCalendar extends Component
         ]);
     }
 
-    public function mount()
+    public function mount($theme)
     {
         $this->months = [
             "Janeiro",
@@ -40,6 +45,10 @@ class AuraAcademicCalendar extends Component
             'array' => []
         ];
 
+        $this->campus = 'chapeco';
+        $this->theme = $theme;
+
+        $this->getCalendarEvents();
         $this->generateCalendar(date('m'), date('Y'));
     }
 
@@ -87,6 +96,25 @@ class AuraAcademicCalendar extends Component
                 $this->calendar['month'] = 0;
             }
         }
+        $this->getCalendarEvents();
         $this->generateCalendar($this->calendar['month'] + 1, $this->calendar['year']);
+    }
+
+    public function getCalendarEvents() {
+        $acController = new AcademicCalendarController();
+
+        $campus = [
+            'chapeco' => 'Chapecó',
+            'laranjeiras_do_sul' => 'Laranjeiras do Sul',
+            'erechim' => 'Erechim',
+            'cerro_largo' => 'Cerro Largo',
+            'realeza' => 'Realeza',
+            'passo_fundo' => 'Passo Fundo'
+        ];
+
+        $this->academicCalendar = $acController->getCalendarEventsByMonth($this->months[$this->calendar['month']], $this->calendar['year'], $campus[$this->campus]);
+        if (count($this->academicCalendar)) {
+            $this->academicCalendar = $this->academicCalendar[0];
+        }
     }
 }

--- a/app/Http/Livewire/AuraAcademicCalendar.php
+++ b/app/Http/Livewire/AuraAcademicCalendar.php
@@ -6,9 +6,63 @@ use Livewire\Component;
 
 class AuraAcademicCalendar extends Component
 {
+    public $months;
+    public $calendar;
+
     public function render()
     {
-        return view('livewire.aura-academic-calendar');
+        return view('livewire.aura-academic-calendar', [
+            'year' => $this->calendar['year'],
+            'month' => $this->calendar['month']
+        ]);
+    }
+
+    public function mount()
+    {
+        $this->months = [
+            "Janeiro",
+            "Fevereiro",
+            "Março",
+            "Abril",
+            "Maio",
+            "Junho",
+            "Julho",
+            "Agosto",
+            "Setembro",
+            "Outubro",
+            "Novembro",
+            "Dezembro"
+        ];
+
+        $this->calendar = [
+            'year' => date('Y'),
+            'month' => date('n') - 1,
+            'array' => []
+        ];
+
+        $this->generateCalendar(date('m'), date('Y'));
+    }
+
+    public function generateCalendar($month, $year)
+    {
+        $date = $year.'-'.$month.'-01';
+
+        $monthArray = [];
+        while (date('m', strtotime($date)) == $month) {
+            $week = [];
+
+            for ($i = 0; $i < 7; $i++) {
+                $day = ['', $i];    
+                if ($i == date('w', strtotime($date)) && date('m', strtotime($date)) == $month) {
+                    $day[0] = date('d', strtotime($date));
+    
+                    $date = date('Y-m-d', strtotime("+1 days",strtotime($date)));
+                }
+                array_push($week, $day);
+            }
+            array_push($monthArray, $week);
+        }
+        $this->calendar['array'] = $monthArray;
     }
 
     public function closePopup()
@@ -18,6 +72,21 @@ class AuraAcademicCalendar extends Component
 
     public function changeMonth($direction)
     {
-        //
+        if ($direction  == 'prev') {
+            $this->calendar['month'] -= 1;
+            if ($this->calendar['month'] < 0) {
+                $this->calendar['year'] -= 1;
+                $this->calendar['month'] = 11;
+            }
+            
+        } else {
+            $this->calendar['month'] += 1;
+
+            if ($this->calendar['month'] > 11) {
+                $this->calendar['year'] += 1;
+                $this->calendar['month'] = 0;
+            }
+        }
+        $this->generateCalendar($this->calendar['month'] + 1, $this->calendar['year']);
     }
 }

--- a/app/Http/Livewire/AuraAcademicCalendar.php
+++ b/app/Http/Livewire/AuraAcademicCalendar.php
@@ -12,17 +12,19 @@ class AuraAcademicCalendar extends Component
     public $calendar;
     public $academicCalendar;
     public $campus;
-    public $theme;
+    public $widgetSettings;
 
     public function render()
     {
         return view('livewire.aura-academic-calendar', [
             'year' => $this->calendar['year'],
-            'month' => $this->calendar['month']
+            'month' => $this->calendar['month'],
+            'theme' => $this->widgetSettings['theme'],
+            'type' => $this->widgetSettings['type']
         ]);
     }
 
-    public function mount($theme)
+    public function mount($widgetSettings)
     {
         $this->months = [
             "Janeiro",
@@ -46,7 +48,7 @@ class AuraAcademicCalendar extends Component
         ];
 
         $this->campus = 'chapeco';
-        $this->theme = $theme;
+        $this->widgetSettings = $widgetSettings;
 
         $this->getCalendarEvents();
         $this->generateCalendar(date('m'), date('Y'));

--- a/app/Http/Livewire/AuraWidget.php
+++ b/app/Http/Livewire/AuraWidget.php
@@ -16,6 +16,9 @@ class AuraWidget extends Component
     public $password;
     public $widgetSettings;
     public $user;
+    public $academicCalendar;
+
+    protected $listeners = ['toggleCalendarPopup'];
 
     public function mount()
     {
@@ -70,14 +73,16 @@ class AuraWidget extends Component
                 $this->user['token'] = null;
             }
         }
+
+        $this->academicCalendar = [
+            'display-popup' => false
+        ];
     }
 
     public function render()
     {   
         return view('livewire.aura-widget');
     }
-
-
 
     public function sendMessage(){
 
@@ -293,5 +298,8 @@ class AuraWidget extends Component
         }
         $this->widgetSettings['history_loaded'] = true;
     }
-     
+
+    public function toggleCalendarPopup() {
+        $this->academicCalendar['display-popup'] = !$this->academicCalendar['display-popup'];
+    }
 }

--- a/public/css/aura-calendar.css
+++ b/public/css/aura-calendar.css
@@ -2,12 +2,18 @@
     background-color: #ECECEC;
     height: 100%;
     width: 100%;
-    overflow: scroll;
-    padding: 10px 15px 0 10px;
+    padding: 10px 0 0 10px;
 }
 
 .page--dark {
     background-color: #041C26;
+}
+
+.popup-body {
+    box-sizing: border-box;
+    max-height: 90%;
+    overflow-y: auto;
+    padding-right: 10px;
 }
 
 .title {
@@ -157,6 +163,7 @@
 .close-btn {
     font-size: 20px;
     padding: 0 10px;
+    margin-right: 10px;
     color: #2F7B9A;
     background-color: transparent;
     border: none;

--- a/public/css/aura-calendar.css
+++ b/public/css/aura-calendar.css
@@ -1,0 +1,163 @@
+.page {
+    background-color: #ECECEC;
+    height: 100%;
+    width: 100%;
+    overflow: scroll;
+    padding: 10px 15px 0 10px;
+}
+
+.page--dark {
+    background-color: #041C26;
+}
+
+.title {
+    color: #2F7B9A;
+    font-size: 28px;
+    padding-top: 10px;
+}
+
+.calendar {
+    background-color: #D9D9D9;
+    border-radius: 5px;
+    padding: 15px;
+    margin-top: 25px;
+    max-width: 400px;
+}
+
+.calendar--dark {
+    background-color: #153E4B;
+    color: #ECECEC;
+}
+
+.calendar-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 3px;
+    border-bottom: 1px solid #888;
+}
+
+.calendar-info {
+    font-weight: bold;
+}
+
+.calendar-week-days {
+    margin-top: 12px;
+}
+
+.calendar-week-days, .week {
+    display: flex;
+    justify-content: space-around;
+}
+
+.day {
+    flex: 1;
+    padding: 5px;
+    width: 100%;
+    margin: 5px;
+    border-radius: 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: 10.52%;
+    position: relative;
+}
+
+.day--no-background {
+    background-color: transparent;
+}
+
+.day--not-weekend {
+    background-color: #F1F1F2;
+}
+
+.calendar--dark .day--not-weekend {
+    background-color: #D9D9D9;
+}
+
+
+.day--weekend, .calendar--dark .day--weekend {
+    background-color: #2F7B9A;
+    color: #BDD0D7;
+}
+
+.day--event, .calendar--dark .day--event {
+    background-color: #FFEFD2;
+    color: #BDD0D7;
+}
+.day span {
+    position: absolute;
+    top:50%; 
+    left:50%; 
+    transform:translate(-50%, -50%); 
+    color: #333333;
+    font-weight: 600;
+}
+
+.day--weekend span {
+    color: #CCCAD2;
+}
+
+.change-month {
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    margin: 5px;
+}
+
+.change-month:active, .change-month:focus {
+    outline: none;
+}
+
+.events {
+    margin-top: 20px;
+}
+
+.event {
+    padding: 5px 0;
+}
+
+.event span {
+    font-weight: bold;
+}
+
+.calendar--dark .change-month, .page--dark .select_label {
+    color: #ECECEC;
+}
+
+.events--dark {
+    color: #ECECEC;
+}
+
+.select_campus {
+    display: block;
+    max-width: 400px;
+    width: 100%;
+    padding: 8px;
+    border: none;
+    border-radius: 5px;
+    background-color: #D9D9D9;
+}
+
+.page--dark .select_campus {
+    display: block;
+    max-width: 400px;
+    width: 100%;
+    padding: 8px;
+    background-color: #153E4B;
+    color: #ECECEC;
+}
+
+.popup-header {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+}
+
+.close-btn {
+    font-size: 20px;
+    padding: 0 10px;
+    background-color: #D9D9D9;
+    border-radius: 5px;
+    border: solid 1px #777;
+}

--- a/public/css/aura-calendar.css
+++ b/public/css/aura-calendar.css
@@ -69,28 +69,6 @@
     position: relative;
 }
 
-.day--no-background {
-    background-color: transparent;
-}
-
-.day--not-weekend {
-    background-color: #F1F1F2;
-}
-
-.calendar--dark .day--not-weekend {
-    background-color: #D9D9D9;
-}
-
-
-.day--weekend, .calendar--dark .day--weekend {
-    background-color: #2F7B9A;
-    color: #BDD0D7;
-}
-
-.day--event, .calendar--dark .day--event {
-    background-color: #FFEFD2;
-    color: #BDD0D7;
-}
 .day span {
     position: absolute;
     top:50%; 
@@ -100,8 +78,16 @@
     font-weight: 600;
 }
 
+.calendar--dark .day span {
+    color: #e1e1e1;
+}
+
 .day--weekend span {
-    color: #CCCAD2;
+    color: #777;
+}
+
+.calendar--dark .day--weekend span {
+    color: #999;
 }
 
 .change-month {

--- a/public/css/aura-calendar.css
+++ b/public/css/aura-calendar.css
@@ -157,7 +157,11 @@
 .close-btn {
     font-size: 20px;
     padding: 0 10px;
-    background-color: #D9D9D9;
-    border-radius: 5px;
-    border: solid 1px #777;
+    color: #2F7B9A;
+    background-color: transparent;
+    border: none;
+}
+
+.page--dark .close-btn {
+    color: #D9D9D9;
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,6 +13,7 @@
         <!-- Styles -->
 
         <link type="text/css" rel="stylesheet" href="{{asset('/css/aura.css')}}">
+        <link type="text/css" rel="stylesheet" href="{{asset('/css/aura-calendar.css')}}">
         <link type="text/css" rel="stylesheet" href="{{asset('/css/analytics.css')}}">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>

--- a/resources/views/livewire/aura-academic-calendar.blade.php
+++ b/resources/views/livewire/aura-academic-calendar.blade.php
@@ -1,4 +1,4 @@
-<div class="page">
+<div class="page page--{{ $theme }}">
     <link rel="stylesheet" href="{{ asset('css/aura-calendar.css')}}">
 
     <div class="popup-header">
@@ -7,8 +7,8 @@
     <h1 class="title">Calendário Acadêmico</h1>
 
     <label class="select_label" for="campus">Selecione o campus:</label>
-    <select class="select_campus" id="campus">
-        <option value="chapeco" selected>Chapecó</option>
+    <select wire:model='campus' class="select_campus" id="campus" wire:change='getCalendarEvents'>
+        <option value="chapeco">Chapecó</option>
         <option value="laranjeiras_do_sul">Laranjeiras do Sul</option>
         <option value="erechim">Erechim</option>
         <option value="cerro_largo">Cerro Largo</option>
@@ -16,7 +16,7 @@
         <option value="passo_fundo">Passo Fundo</option>
     </select>
 
-    <div class="calendar">
+    <div class="calendar calendar--{{ $theme }}">
         <div class="calendar-header">
             <div class="calendar-info">{{ $months[$calendar['month']] }}/{{ $year }}</div>
             <div>
@@ -50,5 +50,24 @@
                 </div>
             @endforeach
         </div>
+    </div>
+
+    <div class="events events--{{ $theme }}">
+        @if (count($academicCalendar) > 0)
+            @foreach ($academicCalendar['events'] as $event)
+                <div class="event">
+                    <span>{{$event['period']}}</span> - 
+                    {{ $event['event'] }}
+                </div>
+            @endforeach
+
+            @foreach ($academicCalendar['festivities'] as $festivity)
+                <div class="event">
+                    {{ $festivity }}
+                </div>
+            @endforeach
+        @else
+            <div>Nenhum evento registrado para este mês!</div>
+        @endif
     </div>
 </div>

--- a/resources/views/livewire/aura-academic-calendar.blade.php
+++ b/resources/views/livewire/aura-academic-calendar.blade.php
@@ -1,73 +1,75 @@
-<div class="page page--{{ $theme }}">
-    <link rel="stylesheet" href="{{ asset('css/aura-calendar.css')}}">
+<div class="page page--{{ $theme }} {{ $type == 'button' ? 'border-radius-15' : ''}} ">
 
     <div class="popup-header">
         <button class="close-btn" wire:click="closePopup">X</button>
     </div>
-    <h1 class="title">Calendário Acadêmico</h1>
+    <div class="popup-body">
 
-    <label class="select_label" for="campus">Selecione o campus:</label>
-    <select wire:model='campus' class="select_campus" id="campus" wire:change='getCalendarEvents'>
-        <option value="chapeco">Chapecó</option>
-        <option value="laranjeiras_do_sul">Laranjeiras do Sul</option>
-        <option value="erechim">Erechim</option>
-        <option value="cerro_largo">Cerro Largo</option>
-        <option value="realeza">Realeza</option>
-        <option value="passo_fundo">Passo Fundo</option>
-    </select>
-
-    <div class="calendar calendar--{{ $theme }}">
-        <div class="calendar-header">
-            <div class="calendar-info">{{ $months[$calendar['month']] }}/{{ $year }}</div>
-            <div>
-                <button class="change-month change-month--prev" wire:click="changeMonth('prev')"><i class="fas fa-angle-left"></i></button>
-                <button class="change-month change-month--next" wire:click="changeMonth('next')"><i class="fas fa-angle-right"></i></button>
+        <h1 class="title">Calendário Acadêmico</h1>
+    
+        <label class="select_label" for="campus">Selecione o campus:</label>
+        <select wire:model='campus' class="select_campus" id="campus" wire:change='getCalendarEvents'>
+            <option value="chapeco">Chapecó</option>
+            <option value="laranjeiras_do_sul">Laranjeiras do Sul</option>
+            <option value="erechim">Erechim</option>
+            <option value="cerro_largo">Cerro Largo</option>
+            <option value="realeza">Realeza</option>
+            <option value="passo_fundo">Passo Fundo</option>
+        </select>
+    
+        <div class="calendar calendar--{{ $theme }}">
+            <div class="calendar-header">
+                <div class="calendar-info">{{ $months[$calendar['month']] }}/{{ $year }}</div>
+                <div>
+                    <button class="change-month change-month--prev" wire:click="changeMonth('prev')"><i class="fas fa-angle-left"></i></button>
+                    <button class="change-month change-month--next" wire:click="changeMonth('next')"><i class="fas fa-angle-right"></i></button>
+                </div>
+            </div>
+    
+            <div class="calendar-week-days">
+                <div>Dom</div>
+                <div>Seg</div>
+                <div>Ter</div>
+                <div>Qua</div>
+                <div>Qui</div>
+                <div>Sex</div>
+                <div>Sáb</div>
+            </div>
+    
+            <div class="calendar-days">
+                @foreach($calendar['array'] as $week)
+                    <div class="week">
+                        @foreach($week as $day)
+                            <div @class([
+                                'day',
+                                'day--not-weekend' => strlen($day[0]) != 0,
+                                'day--weekend' => strlen($day[0]) != 0 && $day[1] >= 6
+                            ])>
+                                <span>{{ $day[0] }}</span>
+                            </div>
+                        @endforeach
+                    </div>
+                @endforeach
             </div>
         </div>
-
-        <div class="calendar-week-days">
-            <div>Dom</div>
-            <div>Seg</div>
-            <div>Ter</div>
-            <div>Qua</div>
-            <div>Qui</div>
-            <div>Sex</div>
-            <div>Sáb</div>
+    
+        <div class="events events--{{ $theme }}">
+            @if (count($academicCalendar) > 0)
+                @foreach ($academicCalendar['events'] as $event)
+                    <div class="event">
+                        <span>{{$event['period']}}</span> - 
+                        {{ $event['event'] }}
+                    </div>
+                @endforeach
+    
+                @foreach ($academicCalendar['festivities'] as $festivity)
+                    <div class="event">
+                        {{ $festivity }}
+                    </div>
+                @endforeach
+            @else
+                <div>Nenhum evento registrado para este mês!</div>
+            @endif
         </div>
-
-        <div class="calendar-days">
-            @foreach($calendar['array'] as $week)
-                <div class="week">
-                    @foreach($week as $day)
-                        <div @class([
-                            'day',
-                            'day--not-weekend' => strlen($day[0]) != 0,
-                            'day--weekend' => strlen($day[0]) != 0 && $day[1] >= 6
-                        ])>
-                            <span>{{ $day[0] }}</span>
-                        </div>
-                    @endforeach
-                </div>
-            @endforeach
-        </div>
-    </div>
-
-    <div class="events events--{{ $theme }}">
-        @if (count($academicCalendar) > 0)
-            @foreach ($academicCalendar['events'] as $event)
-                <div class="event">
-                    <span>{{$event['period']}}</span> - 
-                    {{ $event['event'] }}
-                </div>
-            @endforeach
-
-            @foreach ($academicCalendar['festivities'] as $festivity)
-                <div class="event">
-                    {{ $festivity }}
-                </div>
-            @endforeach
-        @else
-            <div>Nenhum evento registrado para este mês!</div>
-        @endif
     </div>
 </div>

--- a/resources/views/livewire/aura-academic-calendar.blade.php
+++ b/resources/views/livewire/aura-academic-calendar.blade.php
@@ -1,0 +1,41 @@
+    <div class="page">
+
+        <div class="popup-header">
+            <button class="close-btn" wire:click="closePopup">X</button>
+        </div>
+        <h1 class="title">Calendário Acadêmico</h1>
+    
+        <label class="select_label" for="campus">Selecione o campus:</label>
+        <select class="select_campus" id="campus">
+            <option value="chapeco" selected>Chapecó</option>
+            <option value="laranjeiras_do_sul">Laranjeiras do Sul</option>
+            <option value="erechim">Erechim</option>
+            <option value="cerro_largo">Cerro Largo</option>
+            <option value="realeza">Realeza</option>
+            <option value="passo_fundo">Passo Fundo</option>
+        </select>
+
+        <div class="calendar">
+            <div class="calendar-header">            
+                <div class="calendar-info"></div>
+                <div>
+                    <button class="change-month change-month--prev" wire:click="changeMonth('prev')"><i class="fas fa-angle-left"></i></button>
+                    <button class="change-month change-month--next" wire:click="changeMonth('next')"><i class="fas fa-angle-right"></i></button>
+                </div>
+            </div>
+    
+            <div class="calendar-week-days">
+                <div>Dom</div>
+                <div>Seg</div>
+                <div>Ter</div>
+                <div>Qua</div>
+                <div>Qui</div>
+                <div>Sex</div>
+                <div>Sáb</div>
+            </div>
+    
+            <div class="calendar-days">
+                {{-- Generated Calendar --}}
+           </div>
+        </div>
+</div>

--- a/resources/views/livewire/aura-academic-calendar.blade.php
+++ b/resources/views/livewire/aura-academic-calendar.blade.php
@@ -42,8 +42,7 @@
                         @foreach($week as $day)
                             <div @class([
                                 'day',
-                                'day--not-weekend' => strlen($day[0]) != 0,
-                                'day--weekend' => strlen($day[0]) != 0 && $day[1] >= 6
+                                'day--weekend' => strlen($day[0]) != 0 && ($day[1] == 6 or $day[1] == 0)
                             ])>
                                 <span>{{ $day[0] }}</span>
                             </div>

--- a/resources/views/livewire/aura-academic-calendar.blade.php
+++ b/resources/views/livewire/aura-academic-calendar.blade.php
@@ -18,7 +18,7 @@
 
     <div class="calendar">
         <div class="calendar-header">
-            <div class="calendar-info"></div>
+            <div class="calendar-info">{{ $months[$calendar['month']] }}/{{ $year }}</div>
             <div>
                 <button class="change-month change-month--prev" wire:click="changeMonth('prev')"><i class="fas fa-angle-left"></i></button>
                 <button class="change-month change-month--next" wire:click="changeMonth('next')"><i class="fas fa-angle-right"></i></button>
@@ -36,7 +36,19 @@
         </div>
 
         <div class="calendar-days">
-            {{-- Generated Calendar --}}
+            @foreach($calendar['array'] as $week)
+                <div class="week">
+                    @foreach($week as $day)
+                        <div @class([
+                            'day',
+                            'day--not-weekend' => strlen($day[0]) != 0,
+                            'day--weekend' => strlen($day[0]) != 0 && $day[1] >= 6
+                        ])>
+                            <span>{{ $day[0] }}</span>
+                        </div>
+                    @endforeach
+                </div>
+            @endforeach
         </div>
     </div>
 </div>

--- a/resources/views/livewire/aura-academic-calendar.blade.php
+++ b/resources/views/livewire/aura-academic-calendar.blade.php
@@ -1,41 +1,42 @@
-    <div class="page">
+<div class="page">
+    <link rel="stylesheet" href="{{ asset('css/aura-calendar.css')}}">
 
-        <div class="popup-header">
-            <button class="close-btn" wire:click="closePopup">X</button>
-        </div>
-        <h1 class="title">Calendário Acadêmico</h1>
-    
-        <label class="select_label" for="campus">Selecione o campus:</label>
-        <select class="select_campus" id="campus">
-            <option value="chapeco" selected>Chapecó</option>
-            <option value="laranjeiras_do_sul">Laranjeiras do Sul</option>
-            <option value="erechim">Erechim</option>
-            <option value="cerro_largo">Cerro Largo</option>
-            <option value="realeza">Realeza</option>
-            <option value="passo_fundo">Passo Fundo</option>
-        </select>
+    <div class="popup-header">
+        <button class="close-btn" wire:click="closePopup">X</button>
+    </div>
+    <h1 class="title">Calendário Acadêmico</h1>
 
-        <div class="calendar">
-            <div class="calendar-header">            
-                <div class="calendar-info"></div>
-                <div>
-                    <button class="change-month change-month--prev" wire:click="changeMonth('prev')"><i class="fas fa-angle-left"></i></button>
-                    <button class="change-month change-month--next" wire:click="changeMonth('next')"><i class="fas fa-angle-right"></i></button>
-                </div>
+    <label class="select_label" for="campus">Selecione o campus:</label>
+    <select class="select_campus" id="campus">
+        <option value="chapeco" selected>Chapecó</option>
+        <option value="laranjeiras_do_sul">Laranjeiras do Sul</option>
+        <option value="erechim">Erechim</option>
+        <option value="cerro_largo">Cerro Largo</option>
+        <option value="realeza">Realeza</option>
+        <option value="passo_fundo">Passo Fundo</option>
+    </select>
+
+    <div class="calendar">
+        <div class="calendar-header">
+            <div class="calendar-info"></div>
+            <div>
+                <button class="change-month change-month--prev" wire:click="changeMonth('prev')"><i class="fas fa-angle-left"></i></button>
+                <button class="change-month change-month--next" wire:click="changeMonth('next')"><i class="fas fa-angle-right"></i></button>
             </div>
-    
-            <div class="calendar-week-days">
-                <div>Dom</div>
-                <div>Seg</div>
-                <div>Ter</div>
-                <div>Qua</div>
-                <div>Qui</div>
-                <div>Sex</div>
-                <div>Sáb</div>
-            </div>
-    
-            <div class="calendar-days">
-                {{-- Generated Calendar --}}
-           </div>
         </div>
+
+        <div class="calendar-week-days">
+            <div>Dom</div>
+            <div>Seg</div>
+            <div>Ter</div>
+            <div>Qua</div>
+            <div>Qui</div>
+            <div>Sex</div>
+            <div>Sáb</div>
+        </div>
+
+        <div class="calendar-days">
+            {{-- Generated Calendar --}}
+        </div>
+    </div>
 </div>

--- a/resources/views/livewire/aura-widget.blade.php
+++ b/resources/views/livewire/aura-widget.blade.php
@@ -1,3 +1,7 @@
+<div class="h-100">
+@if($academicCalendar['display-popup'])
+    @livewire('aura-academic-calendar')
+@else
 <div class="container-fluid container-fluidd-{{$widgetSettings['theme']}} h-100" >
 
     @if($widgetSettings['type'] == 'button')
@@ -191,4 +195,6 @@
     @if($widgetSettings['type'] == 'button')
         </div>
     @endif
+</div>
+@endif
 </div>

--- a/resources/views/livewire/aura-widget.blade.php
+++ b/resources/views/livewire/aura-widget.blade.php
@@ -1,6 +1,6 @@
 <div class="h-100">
 @if($academicCalendar['display-popup'])
-    @livewire('aura-academic-calendar')
+    @livewire('aura-academic-calendar', ['theme' => $widgetSettings['theme']])
 @else
 <div class="container-fluid container-fluidd-{{$widgetSettings['theme']}} h-100" >
 

--- a/resources/views/livewire/aura-widget.blade.php
+++ b/resources/views/livewire/aura-widget.blade.php
@@ -1,7 +1,5 @@
 <div class="h-100">
-@if($academicCalendar['display-popup'])
-    @livewire('aura-academic-calendar', ['theme' => $widgetSettings['theme']])
-@else
+
 <div class="container-fluid container-fluidd-{{$widgetSettings['theme']}} h-100" >
 
     @if($widgetSettings['type'] == 'button')
@@ -10,9 +8,12 @@
     @endif
 
         <div class="row justify-content-center h-100">
+            @if($academicCalendar['display-popup'])
+                @livewire('aura-academic-calendar', ['widgetSettings' => $widgetSettings    ])
+            @else
             @if($widgetSettings['type'] == 'button')
-                <div class="col-md-12 col-xl-12 chat h-100"  >
-                    <div class="card card-bg-theme-{{$widgetSettings['theme']}} border-radius-15 h-100" >
+            <div class="col-md-12 col-xl-12 chat h-100"  >
+                <div class="card card-bg-theme-{{$widgetSettings['theme']}} border-radius-15 h-100" >
             @elseif($widgetSettings['type'] == 'fullscreen')
                 <div class="chat w-100 h-100"  >
                     <div class="card card-bg-theme-{{$widgetSettings['theme']}} border-radius-0 h-100" >
@@ -191,10 +192,10 @@
                     </div>
                 </div>
             </div>
+            @endif
         </div>
     @if($widgetSettings['type'] == 'button')
         </div>
     @endif
 </div>
-@endif
 </div>


### PR DESCRIPTION
Adiciona um popup para o calendário acadêmico, como ainda não foi adicionada nenhuma pergunta para exibir o popup para testar é necessário adicionar uma forma de abrir o calendario como por exemplo o link: `<a class="open-calendar-popup" wire:click="toggleCalendarPopup">Calendário Acadêmico</a>`. Tentei utilizar cores parecidas com as da nova versão do widget tanto no modo claro quanto escuro.

Popup no modo fullscreen:

![fullscreencalendar](https://user-images.githubusercontent.com/51202548/182141915-1ee1b626-b6f6-4bb3-80c6-4b175775463c.gif)

Popup no modo button:

![calendariotbtn](https://user-images.githubusercontent.com/51202548/182141976-cbb008d4-12d8-42ad-aa28-97fbb2119d3e.gif)

Fix: #70 