### PR TITLE
feat: add academic calendar routes

### DIFF
--- a/app/Http/Controllers/API/V0/AcademicCalendarController.php
+++ b/app/Http/Controllers/API/V0/AcademicCalendarController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\API\V0;
 use App\Http\Controllers\Controller;
 use App\Services\AcademicCalendarService;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -23,7 +24,13 @@ class AcademicCalendarController extends Controller
     public function index(Request $request)
     {
         $validator = Validator::make($request->all(), [
-            'campus' => 'nullable|string'
+            'campus' => [
+                'nullable',
+                'string',
+                Rule::in(['cerro-largo', 'chapeco', 'erechim', 'laranjeiras-do-sul', 'passo-fundo', 'realeza']),
+            ]
+        ], [
+            'in' => 'The :attribute must be one of the following values: :values'
         ]);
 
         if ($validator->fails()) {
@@ -43,9 +50,24 @@ class AcademicCalendarController extends Controller
 
     public function getByMonth(Request $request) {
         $validator = Validator::make($request->all(), [
-            'month' => 'required|numeric|min:0|max:11',
-            'year' => 'required|numeric|digits:4',
-            'campus' => 'nullable|string'
+            'month' => [
+                'required',
+                'numeric',
+                'min:0',
+                'max:11'
+            ],
+            'year' => [
+                'required',
+                'numeric',
+                'digits:4'
+            ],
+            'campus' => [
+                'nullable',
+                'string',
+                Rule::in(['cerro-largo', 'chapeco', 'erechim', 'laranjeiras-do-sul', 'passo-fundo', 'realeza']),
+            ]
+        ], [
+            'in' => 'The :attribute must be one of the following values: :values'
         ]);
 
         if ($validator->fails()) {
@@ -65,9 +87,18 @@ class AcademicCalendarController extends Controller
 
     public function getByDate(Request $request) {
         $validator = Validator::make($request->all(), [
-            'date' => 'required|date_format:Y-m-d',
-            'campus' => 'nullable|string'
-        ]);
+            'date' => [
+                'required',
+                'date_format:d/m/Y'
+            ],
+            'campus' => [
+                'required',
+                'string',
+                Rule::in(['cerro-largo', 'chapeco', 'erechim', 'laranjeiras-do-sul', 'passo-fundo', 'realeza']),
+            ]
+        ], [
+            'in' => 'The :attribute must be one of the following values: :values'
+        ]); 
 
         if ($validator->fails()) {
             return response()->json(
@@ -76,7 +107,7 @@ class AcademicCalendarController extends Controller
             ); 
         }
 
-        $calendars = $this->academicCalendarService->getCalendarEventsByDate($request['date'], $request['campus']);
+        $calendars = $this->academicCalendarService->getCalendarEventsByDate(date("Y-m-d", strtotime(str_replace('/', '-', $request['date']))), $request['campus']);
 
         return response()->json(
             $calendars, 

--- a/app/Http/Controllers/API/V0/AcademicCalendarController.php
+++ b/app/Http/Controllers/API/V0/AcademicCalendarController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers\API\V0;
+use App\Http\Controllers\Controller;
+use App\Services\AcademicCalendarService;
+use Illuminate\Support\Facades\Validator;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class AcademicCalendarController extends Controller
+{
+    protected AcademicCalendarService $academicCalendarService;
+
+    public function __construct()
+    {
+        $this->academicCalendarService = new AcademicCalendarService();
+    }
+
+    /**
+    * @return Response
+    */
+    public function index(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'campus' => 'nullable|string'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(
+                ['errors' => $validator->errors()], 
+                Response::HTTP_BAD_REQUEST
+            ); 
+        }
+
+        $calendars = $this->academicCalendarService->getCalendars();
+
+        return response()->json(
+            $calendars, 
+            Response::HTTP_OK
+        ); 
+    }
+
+    public function getByMonth(Request $request) {
+        $validator = Validator::make($request->all(), [
+            'month' => 'required|numeric|min:0|max:11',
+            'year' => 'required|numeric|digits:4',
+            'campus' => 'nullable|string'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(
+                ['errors' => $validator->errors()], 
+                Response::HTTP_BAD_REQUEST
+            ); 
+        }
+
+        $calendars = $this->academicCalendarService->getCalendarEventsByMonth($request['month'], $request['year'], $request['campus']);
+
+        return response()->json(
+            $calendars, 
+            Response::HTTP_OK
+        ); 
+    }
+
+    public function getByDate(Request $request) {
+        $validator = Validator::make($request->all(), [
+            'date' => 'required|date_format:Y-m-d',
+            'campus' => 'nullable|string'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(
+                ['errors' => $validator->errors()], 
+                Response::HTTP_BAD_REQUEST
+            ); 
+        }
+
+        $calendars = $this->academicCalendarService->getCalendarEventsByDate($request['date'], $request['campus']);
+
+        return response()->json(
+            $calendars, 
+            Response::HTTP_OK
+        ); 
+    }
+
+}

--- a/app/Services/AcademicCalendarService.php
+++ b/app/Services/AcademicCalendarService.php
@@ -26,11 +26,11 @@ class AcademicCalendarService
 
         $this->campus = [
             'chapeco' => 'Chapecó',
-            'laranjeiras_do_sul' => 'Laranjeiras do Sul',
+            'laranjeiras-do-sul' => 'Laranjeiras do Sul',
             'erechim' => 'Erechim',
-            'cerro_largo' => 'Cerro Largo',
+            'cerro-largo' => 'Cerro Largo',
             'realeza' => 'Realeza',
-            'passo_fundo' => 'Passo Fundo'
+            'passo-fundo' => 'Passo Fundo'
         ];
     }
 

--- a/app/Services/AcademicCalendarService.php
+++ b/app/Services/AcademicCalendarService.php
@@ -35,8 +35,12 @@ class AcademicCalendarService
     }
 
     public function getCalendars($campus = null) {
-        if (!isset($this->campus[$campus])){
+        if ($campus != null && !isset($this->campus[$campus])){
             return [];
+        }
+
+        if ($campus == null) {
+            return AcademicCalendar::all();
         }
 
         $calendars = AcademicCalendar::where('title', 'LIKE', '%' . $this->campus[$campus] . '%')->get();
@@ -55,6 +59,7 @@ class AcademicCalendarService
 
     public function getCalendarEventsByMonth($month, $year, $campus = null) {
         $calendars = $this->getCalendars($campus);
+        $month = $this->months[$month];
 
         $currentMonthEvents = [];
         foreach ($calendars as $calendar) {
@@ -85,7 +90,7 @@ class AcademicCalendarService
         $dateCalendar = [];
         $date = strtotime($date);
 
-        $month = $this->months[(int) date('n', $date) - 1];
+        $month = (int) date('n', $date) - 1;
         $year = date('Y', $date);
         $monthCalendars = $this->getCalendarEventsByMonth($month, $year, $campus);
 

--- a/routes/api/v0.php
+++ b/routes/api/v0.php
@@ -41,6 +41,11 @@ Route::get('/widgets/aura', AuraWidget::class);
 // Show Analytics 
 Route::get('/analytics/show', ShowAnalytics::class);
 
+// Calendário Acadêmico
+Route::get('/academic-calendar', [AcademicCalendarController::class, 'index']);
+Route::get('/academic-calendar/get-by-month', [AcademicCalendarController::class, 'getByMonth']);
+Route::get('/academic-calendar/get-by-date', [AcademicCalendarController::class, 'getByDate']);
+
 // Authendicated routes
 Route::group(['middleware' => 'jwt.practice'], function () {
 
@@ -69,10 +74,6 @@ Route::group(['middleware' => 'jwt.practice'], function () {
     Route::patch('/app-bem-estar/questionnaire/{id}', [WellBeingQuestionnaireController::class, 'update']);
     Route::delete('/app-bem-estar/questionnaire/{id}', [WellBeingQuestionnaireController::class, 'destroy']);
 
-    // Calendário Acadêmico
-    Route::get('/academic-calendar', [AcademicCalendarController::class, 'index']);
-    Route::get('/academic-calendar/get-by-month', [AcademicCalendarController::class, 'getByMonth']);
-    Route::get('/academic-calendar/get-by-date', [AcademicCalendarController::class, 'getByDate']);
 
     // Notification
     Route::get('user/notify/push', [NotificationController::class, 'push']);

--- a/routes/api/v0.php
+++ b/routes/api/v0.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\API\V0\TestController;
 use App\Http\Controllers\API\V0\UserController;
 use App\Http\Controllers\API\V0\AnalyticsController;
 use App\Http\Controllers\API\V0\WellBeingQuestionnaireController;
+use App\Http\Controllers\API\V0\AcademicCalendarController;
 use App\Http\Proxy\PracticeApiProxy;
 use App\Http\Livewire\AuraWidget;
 use App\Http\Livewire\ShowAnalytics;
@@ -67,6 +68,11 @@ Route::group(['middleware' => 'jwt.practice'], function () {
     Route::get('/app-bem-estar/questionnaire/{id}', [WellBeingQuestionnaireController::class, 'show']);
     Route::patch('/app-bem-estar/questionnaire/{id}', [WellBeingQuestionnaireController::class, 'update']);
     Route::delete('/app-bem-estar/questionnaire/{id}', [WellBeingQuestionnaireController::class, 'destroy']);
+
+    // Calendário Acadêmico
+    Route::get('/academic-calendar', [AcademicCalendarController::class, 'index']);
+    Route::get('/academic-calendar/get-by-month', [AcademicCalendarController::class, 'getByMonth']);
+    Route::get('/academic-calendar/get-by-date', [AcademicCalendarController::class, 'getByDate']);
 
     // Notification
     Route::get('user/notify/push', [NotificationController::class, 'push']);


### PR DESCRIPTION
Adiciona três novas rotas para buscar as informações do Calendário Acadêmico. Uma para buscar todos os calendários, uma para buscar um mês especifico e outra para buscar os eventos de uma data especifica. Nos três casos é possível adicionar um campo `campus` no corpo da requisição para buscar apenas os dados de um campus específico. 

fix: #97 