### PR TITLE
feat: add aura answers

### DIFF
--- a/app/Http/Middleware/PracticeJwtPassport.php
+++ b/app/Http/Middleware/PracticeJwtPassport.php
@@ -3,6 +3,8 @@
 namespace App\Http\Middleware;
 
 use App\Auth\CredentialManager;
+use Illuminate\Http\Response;
+
 use Closure;
 
 class PracticeJwtPassport
@@ -27,7 +29,7 @@ class PracticeJwtPassport
         try {
             $this->credentialManager->checkPassportThenLocalyAuthenticate($request->bearerToken());
         } catch (\Exception $e) {
-            return response()->json(['error' => $e->getMessage()]);
+            return response()->json(['error' => $e->getMessage()], Response::HTTP_UNAUTHORIZED);
         }
         return $next($request);
     }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -41,6 +41,7 @@ const app = new Vue({
         messages: [{id: 1, message: "Olá! Eu me chamo aura, sua assistente virtual.", source: "aura", assessed: 2}],
         showHeader: true,
         userTheme: "light-theme",
+        userToken: "",
     },
 
     mounted() {

--- a/resources/js/components/InputComponent.vue
+++ b/resources/js/components/InputComponent.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="input-bar">
         <div class="input-group">
-            <input v-model="inputMessage" name="message" @keyup.enter="sendMessage" type="text" class="form-control text-input" placeholder="O que deseja saber?" @focus="changeHeaderDisplay()" @blur="changeHeaderDisplay()"/>
+            <input v-model="inputMessage" name="message" @keyup.enter="sendMessage" type="text" class="form-control text-input" placeholder="O que deseja saber?" @focus="changeHeaderDisplay()" @blur="changeHeaderDisplay()" :disabled="disabled"/>
             <a class="input-group-text send-button" @click="sendMessage"><img src="/img/aura/sendIcon.png" class="send-icon"></a>
         </div>
     </div>
@@ -9,11 +9,13 @@
 
 <script>
 export default {
-    props: ["messages", "showheader"],
+    props: ["messages", "showheader", "usertoken"],
 
     data() {
         return {
             inputMessage: "",
+            userToken: this.usertoken,
+            disabled:  false,
         };
     },
     methods: {
@@ -23,13 +25,57 @@ export default {
         },  
 
         sendMessage() {
-            //Emit a "messagesent" event including the user who sent the message along with the message content
-            this.$emit("messageSent", {
-                //newMessage is bound to the earlier "btn-input" input field
-                message: this.inputMessage,
+            if (this.inputMessage == ""){
+                return;
+            }
+            this.disabled =  true;
+
+            this.messages.push({id: this.messages.length + 1, message: this.inputMessage, source: "user", assessed: 2})
+
+            var encodedMessage = encodeURIComponent(this.inputMessage);
+            var requestUrl = "/v0/aura/nlp/domain/" + encodedMessage
+
+            axios({
+                method: "GET",
+                url: requestUrl,
+                headers: {
+                    Authorization: `Bearer ${this.userToken}`
+                }
+            }).then((response) => {
+                const data = response.data;
+                var auraAnswer = "";
+
+                if (data.answer != undefined) {
+                    auraAnswer = data.answer;
+                } else {
+                    auraAnswer = "Não tenho resposta para isso.";
+                }
+
+                this.messages.push({id: this.messages.length + 1, message: auraAnswer, source: "aura", assessed: 2})
+
+                this.disabled =  false;
+
+            }).catch((error) => {
+                if (error.response.status == 401) {
+                    this.messages.push({
+                        id: this.messages.length + 1, 
+                        message: "Para poder conversar comigo você precisa estar autenticado(a). Por favor autentique-se:", 
+                        source: "aura", 
+                        assessed: 2
+                    })
+                    // Mostrar o formulário de login
+                } else if(error.response.status == 500) {
+                    this.messages.push({
+                        id: this.messages.length + 1, 
+                        message: "Algo de errado está acontecendo com meus servidores, bip bop.", 
+                        source: "aura", 
+                        assessed: 2
+                    })
+                }
+                this.disabled =  false;
             });
-            //Clear the input
-            this.newMessage = "";
+
+            this.inputMessage = "";
         },
     },
 };

--- a/resources/views/livewire/aura-widget.blade.php
+++ b/resources/views/livewire/aura-widget.blade.php
@@ -6,7 +6,7 @@
                     <header-component :showheader.sync="showHeader"></header-component>
 
                     <div id="chat-body" class="chat-body msg_card_body" onscroll="handleHeader()">
-                        <message-component :message="messages"></message-component>
+                        <message-component :message.sync="messages"></message-component>
                         {{-- <div wire:loading.delay wire:target="sendMessage" class="aura_typing text-secondary">
                             Aura está digitando... achar algum substituto em Vue
                         </div>  --}} 
@@ -59,7 +59,7 @@
                     @endif --}}
 
                     </div>
-                    <input-component :showheader.sync="showHeader"></input-component>
+                    <input-component :usertoken.sync="userToken" :messages.sync="messages" :showheader.sync="showHeader"></input-component>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Adicionei as respostas da Aura para as mensagens enviadas pelo usuário. Como a parte de login ainda não foi feita eu adicionei um token válido manualmento no arquivo `resources/js/app.js` para testar. 


Resposta caso ocorra algum problema com o token:

![image](https://user-images.githubusercontent.com/51202548/186922146-f8d28461-755c-4285-a344-006d103dae6b.png)

Resposta caso tudo dê certo:

![image](https://user-images.githubusercontent.com/51202548/186922345-e73050e5-1cec-4507-ad80-aa0e0f719bc2.png)


Aproveitei para ajustar o retorno do middleware de autenticação caso o token fornecido seja inválido para facilitar o tratamento das respostas, agora quando não é enviado um token ou o token enviado é inválido a API retorna o status `401`.

Fix: #105 