### PR TITLE
feat: consent to use data

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -60,6 +60,7 @@ const app = new Vue({
         showLogin: true,
         userTheme: "light-theme",
         userToken: "",
+        dataUseAllowed: false
     },
 
     mounted() {
@@ -102,7 +103,43 @@ const app = new Vue({
                 }
             }).then(()=>{
                 this.userToken = urlToken;
+                this.getUserConsentStatus();
             }).catch(e => console.error(e));
+        },
+        getUserConsentStatus() {
+            axios({
+                method: "GET",
+                url: "/v0/aura/chat/consent-status",
+                headers: {
+                    Authorization: `Bearer ${this.userToken}`
+                }
+            }).then((response)=>{
+                if (response.data.aura_consent == "1") {
+                    this.dataUseAllowed = true;
+                } else {
+                    this.dataUseAllowed = false;
+                }
+            }).catch(e => console.error(e));
+        },
+        userDenyUseOfData() {
+            this.dataUseAllowed = false;
+            this.messages.push({
+                id: 1, 
+                message: "Mensagem falando que não é possível usar a Aura sem consentir com o uso de dados e falando que é possível mudar esta escolha caso o usuário deseje", 
+                source: "aura",
+                userMessage: "has_no_message", 
+                category: "user_not_consent"
+            });
+        },
+        userAllowUseOfData() {
+            this.dataUseAllowed = true;
+            this.messages.push({
+                id: 1, 
+                message: "Mensagem agradecendo e falando que agora o usuário pode utilizar a Aura normalmente", 
+                source: "aura",
+                userMessage: "has_no_message", 
+                category: "user_not_consent"
+            });
         }
     }
 });

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -118,6 +118,13 @@ const app = new Vue({
                     this.dataUseAllowed = true;
                 } else {
                     this.dataUseAllowed = false;
+                    this.messages.push({
+                        id: 1, 
+                        message: "Mensagem falando que não é possível usar a Aura sem consentir com o uso de dados e falando que é possível mudar esta escolha caso o usuário deseje", 
+                        source: "aura",
+                        userMessage: "has_no_message", 
+                        category: "user_not_consent"
+                    });
                 }
             }).catch(e => console.error(e));
         },

--- a/resources/js/components/ConsentComponent.vue
+++ b/resources/js/components/ConsentComponent.vue
@@ -4,7 +4,7 @@
         <br>Você aceita que alguns dos seus dados sejam armazenados?
         <div style="display: flex;justify-content: space-around; margin-top:50px">
             <button class="accept" @click="handleConsent(1)">Permitir</button>
-            <button class="deny" @click="handleConsent(2)">Negar</button>
+            <button class="deny" @click="handleConsent(0)">Negar</button>
         </div>
     </div>
 </template>
@@ -20,9 +20,28 @@ export default {
     },
 
     methods: {
-        handleConsent(resposta) {
-            //TODO: Processar todo a parte de limpar o histórico
+        handleConsent(consentStatus) {
             this.$emit('update:showconsentpop', !this.showconsentpop);
+
+            axios({
+                method: "POST",
+                url: "/v0/aura/chat/consent-status",
+                headers: {
+                    "Authorization": `Bearer ${this.usertoken}`,
+                    "Content-Type": "application/json",
+                },
+                data: {
+                    "consent_status": consentStatus,
+                }
+            }).then(() => {
+                if (consentStatus) {
+                    this.$emit('userallow');
+                } else {
+                    this.$emit('userdeny');
+                }
+            }).catch((e) => {
+                console.log(e.response)
+            });
         },
     },
 }

--- a/resources/js/components/InputComponent.vue
+++ b/resources/js/components/InputComponent.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="input-bar">
         <div class="input-group">
-            <input v-model="inputMessage" autocomplete="off" name="message" @keyup.enter="sendMessage" type="text" class="form-control text-input" placeholder="O que deseja saber?" @focus="changeHeaderDisplay()" @blur="changeHeaderDisplay()" :disabled="disabled"/>
+            <input v-model="inputMessage" autocomplete="off" name="message" @keyup.enter="sendMessage" type="text" class="form-control text-input" placeholder="O que deseja saber?" @focus="changeHeaderDisplay()" @blur="changeHeaderDisplay()" :disabled="disabled || !datauseallowed"/>
             <a class="input-group-text send-button" @click="sendMessage"><img src="/img/aura/sendIcon.png" class="send-icon"></a>
         </div>
     </div>
@@ -9,7 +9,7 @@
 
 <script>
 export default {
-    props: ["messages", "showheader", "usertoken"],
+    props: ["messages", "showheader", "usertoken", 'datauseallowed'],
 
     data() {
         return {

--- a/resources/views/livewire/aura-widget.blade.php
+++ b/resources/views/livewire/aura-widget.blade.php
@@ -6,7 +6,7 @@
                     <header-component :usertoken.sync="userToken" :showconsentpop.sync="showConsentPopup" :showheader.sync="showHeader"></header-component>
 
                     <login-component :showlogin.sync="showLogin"></login-component>
-                    <consent-component :showconsentpop.sync="showConsentPopup"></consent-component>
+                    <consent-component @userallow="userAllowUseOfData()" @userdeny="userDenyUseOfData()" :usertoken.sync="userToken" :showconsentpop.sync="showConsentPopup"></consent-component>
 
                     <div id="chat-body" class="chat-body msg_card_body" onscroll="handleHeader()">
                         <message-component :usertoken.sync="userToken" :message.sync="messages"></message-component>
@@ -14,7 +14,7 @@
                             Aura está digitando... achar algum substituto em Vue
                         </div>  --}} 
                     </div>
-                    <input-component :usertoken.sync="userToken" :messages.sync="messages" :showheader.sync="showHeader"></input-component>
+                    <input-component :datauseallowed.sync='dataUseAllowed' :usertoken.sync="userToken" :messages.sync="messages" :showheader.sync="showHeader"></input-component>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Integra o consentimento para o uso de dados com o backend. Impedi que o usuário enviasse mensagem caso o mesmo não consentisse com o uso de dados. A principio deixei mensagens que vão precisar ser alteradas antes de colocar a Aura em produção.

fix: #118 